### PR TITLE
Remove --no-use-wheel flag when running pip

### DIFF
--- a/pydep/req.py
+++ b/pydep/req.py
@@ -110,7 +110,7 @@ class SetupToolsRequirement(object):
         """Downloads this requirement from PyPI and returns metadata from its setup.py. Returns an error string or None if no error."""
         tmpdir = tempfile.mkdtemp()
         with open(os.devnull, 'w') as devnull:
-            subprocess.call(['pip', 'install', '--build',  tmpdir, '--upgrade', '--force-reinstall', '--no-install', '--no-deps', '--no-use-wheel', str(self.req)],
+            subprocess.call(['pip', 'install', '--build',  tmpdir, '--upgrade', '--force-reinstall', '--no-install', '--no-deps', str(self.req)],
                             stdout=devnull, stderr=devnull)
         projectdir = path.join(tmpdir, self.req.project_name)
         setup_dict, err = setup_py.setup_info_dir(projectdir)


### PR DESCRIPTION
--no-use-wheel is not a flag for `pip install` but for `pip wheel`.  This flag crashes the subprocess causing it to fail and making the script think there is no `setup.py` file for projects that it downloads.
