### PR TITLE
Fix PIP 6.0+ compatibility

### DIFF
--- a/pydep/req.py
+++ b/pydep/req.py
@@ -60,7 +60,7 @@ def requirements_from_requirements_txt(rootdir):
 
     all_reqs = {}
     for f in req_files:
-        for install_req in pip.req.parse_requirements(f):
+        for install_req in pip.req.parse_requirements(f, session=pip.download.PipSession()):
             if install_req.url is not None:
                 req = PipURLInstallRequirement(install_req)
             else:
@@ -131,7 +131,7 @@ class PipURLInstallRequirement(object):
     """
     This represents a URL requirement as seen by pip (e.g., 'git+git://github.com/foo/bar/').
     Such a requirement is not a valid requirement by setuptools standards. (In a setup.py, you would add the name/version
-    of the requirement to install_requires as with PyPI packages, and then add the URL link to dependency_links.  
+    of the requirement to install_requires as with PyPI packages, and then add the URL link to dependency_links.
     Also included archive files such as *.zip, *.tar, *.zip.gz, or *.tar.gz)
     The constructor takes a pip.req.InstallRequirement.
     """

--- a/pydep/req_test.py
+++ b/pydep/req_test.py
@@ -152,8 +152,7 @@ class Test_requirements(unittest.TestCase):
         _, requirements_file = tempfile.mkstemp()
         with open(requirements_file, 'w') as f:
             f.write(requirements_str)
-        pip_reqs = pip.req.parse_requirements(requirements_file)
-        reqs = [PipVCSInstallRequirement(r).to_dict() for r in pip_reqs]
+        pip_reqs = pip.req.parse_requirements(requirements_file, session=pip.download.PipSession())
         os.remove(requirements_file)
 
         self.assertListEqual(expected, reqs)

--- a/pydep/req_test.py
+++ b/pydep/req_test.py
@@ -153,6 +153,7 @@ class Test_requirements(unittest.TestCase):
         with open(requirements_file, 'w') as f:
             f.write(requirements_str)
         pip_reqs = pip.req.parse_requirements(requirements_file, session=pip.download.PipSession())
+        reqs = [PipURLInstallRequirement(r).to_dict() for r in pip_reqs]
         os.remove(requirements_file)
 
         self.assertListEqual(expected, reqs)


### PR DESCRIPTION
This fixes #8. It also should work with last versions of `1.5.x`.