### PR TITLE
Use pip download

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For example,
 Additional requirements
 -----
 - Unix (Windows is untested and will probably fail, because, e.g., things get piped to /dev/null in a few places)
-- pip 1.5+
+- pip 7.0+
 - curl, unzip, gunzip, tar
 
 Tests

--- a/pydep-run.py
+++ b/pydep-run.py
@@ -79,7 +79,7 @@ def dep(args):
     print(json.dumps(reqs))
 
 
-def smoke_test():
+def smoke_test(args):
     """Test subcommand that runs pydep on a few popular repositories and prints the results."""
     testcases = [
         ('Flask', 'https://github.com/mitsuhiko/flask.git'),

--- a/pydep-run.py
+++ b/pydep-run.py
@@ -6,18 +6,21 @@ import argparse
 import pydep.req
 import pydep.setup_py
 
-from os import system, path
+from os import path
 import subprocess
 import tempfile
 import shutil
 
+
 def main():
     # Parse args
-    argparser = argparse.ArgumentParser(description='pydep is simple command line tool that tells you about package dependency metadata in Python')
+    argparser = argparse.ArgumentParser(
+        description='pydep is simple command line tool that tells you about package dependency metadata in Python')
     subparsers = argparser.add_subparsers()
 
     dep_parser = subparsers.add_parser('dep', help='print the dependencies of a python project in JSON')
-    dep_parser.add_argument('--raw', action='store_true', help='If true, pydep will not try to resolve dependencies to VCS URLs')
+    dep_parser.add_argument('--raw', action='store_true',
+                            help='If true, pydep will not try to resolve dependencies to VCS URLs')
     dep_parser.add_argument('dir', help='path to root directory of project code')
     dep_parser.set_defaults(func=dep)
 
@@ -29,7 +32,9 @@ def main():
     list_info_parser.add_argument('dir', help='path to containing directory')
     list_info_parser.set_defaults(func=list_info)
 
-    smoke_parser = subparsers.add_parser('demo', help='run pydep against some popular repositories, printing out dependency information about each')
+    smoke_parser = subparsers.add_parser('demo',
+                                         help='run pydep against some popular repositories, printing out dependency'
+                                              ' information about each')
     smoke_parser.set_defaults(func=smoke_test)
 
     args = argparser.parse_args()
@@ -39,6 +44,7 @@ def main():
 #
 # Sub-commands
 #
+
 
 def list_info(args):
     """Subcommand to print out metadata of all packages contained in a directory"""
@@ -50,8 +56,10 @@ def list_info(args):
         if err is not None:
             sys.stderr.write('failed due to error: %s\n' % err)
             sys.exit(1)
-        setup_infos.append(setup_dict_to_json_serializable_dict(setup_dict, rootdir=path.relpath(setup_dir, container_dir)))
-    print json.dumps(setup_infos)
+        setup_infos.append(
+            setup_dict_to_json_serializable_dict(setup_dict, rootdir=path.relpath(setup_dir, container_dir)))
+    print(json.dumps(setup_infos))
+
 
 def info(args):
     """Subcommand to print out metadata of package"""
@@ -59,7 +67,8 @@ def info(args):
     if err is not None:
         sys.stderr.write('failed due to error: %s\n' % err)
         sys.exit(1)
-    print json.dumps(setup_dict_to_json_serializable_dict(setup_dict))
+    print(json.dumps(setup_dict_to_json_serializable_dict(setup_dict)))
+
 
 def dep(args):
     """Subcommand to print out dependencies of project"""
@@ -67,9 +76,10 @@ def dep(args):
     if err is not None:
         sys.stderr.write('failed due to error: %s\n' % err)
         sys.exit(1)
-    print json.dumps(reqs)
+    print(json.dumps(reqs))
 
-def smoke_test(args):
+
+def smoke_test():
     """Test subcommand that runs pydep on a few popular repositories and prints the results."""
     testcases = [
         ('Flask', 'https://github.com/mitsuhiko/flask.git'),
@@ -77,42 +87,45 @@ def smoke_test(args):
         # TODO: update smoke_test to call setup_dirs/list instead of assuming setup.py exists at the repository root
         # ('Node', 'https://github.com/joyent/node.git'),
     ]
+    tmpdir = None
     try:
         tmpdir = tempfile.mkdtemp()
         for title, cloneURL in testcases:
-            print 'Downloading and processing %s...' % title
+            print('Downloading and processing %s...' % title)
             subdir = path.splitext(path.basename(cloneURL))[0]
             dir_ = path.join(tmpdir, subdir)
             with open('/dev/null', 'w') as devnull:
                 subprocess.call(['git', 'clone', cloneURL, dir_], stdout=devnull, stderr=devnull)
 
-            print ''
+            print('')
             reqs, err = pydep.req.requirements(dir_, True)
             if err is None:
-                print 'Here is some info about the dependencies of %s' % title
+                print('Here is some info about the dependencies of %s' % title)
                 if len(reqs) == 0:
-                    print '(There were no dependencies found for %s)' % title
+                    print('(There were no dependencies found for %s)' % title)
                 else:
-                    print json.dumps(reqs, indent=2)
+                    print(json.dumps(reqs, indent=2))
             else:
-                print 'failed with error: %s' % err
+                print('failed with error: %s' % err)
 
-            print ''
+            print('')
             setup_dict, err = pydep.setup_py.setup_info_dir(dir_)
             if err is None:
-                print 'Here is the metadata for %s' % title
-                print json.dumps(setup_dict_to_json_serializable_dict(setup_dict), indent=2)
+                print('Here is the metadata for %s' % title)
+                print(json.dumps(setup_dict_to_json_serializable_dict(setup_dict), indent=2))
             else:
-                print 'failed with error: %s' % err
+                print('failed with error: %s' % err)
 
     except Exception as e:
-        print 'failed with exception %s' % str(e)
+        print('failed with exception %s' % str(e))
     finally:
-        shutil.rmtree(tmpdir)
+        if tmpdir:
+            shutil.rmtree(tmpdir)
 
 #
 # Helpers
 #
+
 
 def setup_dict_to_json_serializable_dict(d, **kw):
     return {

--- a/pydep/req.py
+++ b/pydep/req.py
@@ -116,24 +116,24 @@ class SetupToolsRequirement(object):
         Downloads this requirement from PyPI and returns metadata from its setup.py.
         Returns an error string or None if no error.
         """
-        tmpdir = tempfile.mkdtemp()
+        tmp_dir = tempfile.mkdtemp()
         with open(os.devnull, 'w') as devnull:
             try:
                 cmd = ['pip', 'install',
-                       '--build',  tmpdir,
-                       '--upgrade', '--force-reinstall',
-                       '--no-install', '--no-deps',
-                       '--no-use-wheel', str(self.req)]
+                       '--download',  tmp_dir,
+                       '--build',  tmp_dir,
+                       '--no-clean', '--no-deps',
+                       '--no-binary', ':all:', str(self.req)]
                 subprocess.check_call(cmd, stdout=devnull, stderr=devnull)
             except Exception as e:
-                shutil.rmtree(tmpdir)
+                shutil.rmtree(tmp_dir)
                 return 'error downloading requirement: %s' % str(e)
 
-        projectdir = path.join(tmpdir, self.req.project_name)
-        setup_dict, err = setup_py.setup_info_dir(projectdir)
+        project_dir = path.join(tmp_dir, self.req.project_name)
+        setup_dict, err = setup_py.setup_info_dir(project_dir)
         if err is not None:
             return None, err
-        shutil.rmtree(tmpdir)
+        shutil.rmtree(tmp_dir)
 
         self.metadata = setup_dict
         return None

--- a/pydep/req.py
+++ b/pydep/req.py
@@ -13,8 +13,9 @@ import re
 from glob import glob
 from os import path
 
-import setup_py
-from vcs import parse_repo_url
+from pydep import setup_py
+from pydep.vcs import parse_repo_url
+
 
 def requirements(rootdir, resolve=True):
     """
@@ -30,10 +31,11 @@ def requirements(rootdir, resolve=True):
     if resolve:
         for req in reqs:
             err = req.resolve()
-            if err != None:
+            if err is not None:
                 sys.stderr.write('error resolving requirement %s: %s\n' % (str(req), err))
 
     return [r.to_dict() for r in reqs], None
+
 
 def requirements_from_setup_py(rootdir):
     """
@@ -51,7 +53,9 @@ def requirements_from_setup_py(rootdir):
             reqs.append(SetupToolsRequirement(pr.Requirement.parse(req_str)))
     return reqs, None
 
+
 REQUIREMENTS_FILE_GLOB = '*requirements*.txt'
+
 
 def requirements_from_requirements_txt(rootdir):
     req_files = glob(path.join(rootdir, REQUIREMENTS_FILE_GLOB))
@@ -61,7 +65,7 @@ def requirements_from_requirements_txt(rootdir):
     all_reqs = {}
     for f in req_files:
         for install_req in pip.req.parse_requirements(f, session=pip.download.PipSession()):
-            if install_req.url is not None:
+            if install_req.link is not None:
                 req = PipURLInstallRequirement(install_req)
             else:
                 req = SetupToolsRequirement(install_req.req)
@@ -108,12 +112,19 @@ class SetupToolsRequirement(object):
         }
 
     def resolve(self):
-        """Downloads this requirement from PyPI and returns metadata from its setup.py. Returns an error string or None if no error."""
+        """
+        Downloads this requirement from PyPI and returns metadata from its setup.py.
+        Returns an error string or None if no error.
+        """
         tmpdir = tempfile.mkdtemp()
         with open(os.devnull, 'w') as devnull:
             try:
-                subprocess.check_call(['pip', 'install', '--build',  tmpdir, '--upgrade', '--force-reinstall', '--no-install', '--no-deps', '--no-use-wheel', str(self.req)],
-                                      stdout=devnull, stderr=devnull)
+                cmd = ['pip', 'install',
+                       '--build',  tmpdir,
+                       '--upgrade', '--force-reinstall',
+                       '--no-install', '--no-deps',
+                       '--no-use-wheel', str(self.req)]
+                subprocess.check_call(cmd, stdout=devnull, stderr=devnull)
             except Exception as e:
                 shutil.rmtree(tmpdir)
                 return 'error downloading requirement: %s' % str(e)
@@ -127,27 +138,31 @@ class SetupToolsRequirement(object):
         self.metadata = setup_dict
         return None
 
+
 class PipURLInstallRequirement(object):
     """
     This represents a URL requirement as seen by pip (e.g., 'git+git://github.com/foo/bar/').
-    Such a requirement is not a valid requirement by setuptools standards. (In a setup.py, you would add the name/version
-    of the requirement to install_requires as with PyPI packages, and then add the URL link to dependency_links.
+    Such a requirement is not a valid requirement by setuptools standards. (In a setup.py,
+    you would add the name/version of the requirement to install_requires as with PyPI packages,
+    and then add the URL link to dependency_links.
     Also included archive files such as *.zip, *.tar, *.zip.gz, or *.tar.gz)
     The constructor takes a pip.req.InstallRequirement.
     """
+    _archive_regex = re.compile('^(http|https)://[^/]+/.+\.(zip|tar)(\.gz|)$', re.IGNORECASE)
+
     def __init__(self, install_req):
         self._install_req = install_req
-        if install_req.url is None:
+        if install_req.link is None:
             raise 'No URL found in install_req: %s' % str(install_req)
-        self.url = parse_repo_url(install_req.url)
+        self.url = parse_repo_url(install_req.link.url)
         self.metadata = None
         self.vcs = None
         self.type = 'vcs'
-        if install_req.url.find('+') >= 0:
-            self.vcs = install_req.url[:install_req.url.find('+')]
-        elif re.compile(r'^(http|https)://[^/]+/.+\.(zip|tar)(\.gz|)$', re.IGNORECASE).match(install_req.url) is not None:
+        if install_req.link.url.find('+') >= 0:
+            self.vcs = install_req.link.url[:install_req.link.url.find('+')]
+        elif self._archive_regex.match(install_req.link.url) is not None:
             self.type = 'archive'
-        self.setuptools_req = install_req.req # may be None
+        self.setuptools_req = install_req.req  # may be None
 
     def __str__(self):
         return self.url.__str__()
@@ -203,7 +218,11 @@ class PipURLInstallRequirement(object):
                 elif install_url.endswith(".zip"):
                     subprocess.call(['unzip', '-j', '-o', tmparchive, '-d', tmpdir], stdout=devnull, stderr=devnull)
             else:
-                return 'cannot resolve requirement %s (from %s) with unrecognized VCS: %s' % (str(self), str(self._install_req), self.vcs)
+                return 'cannot resolve requirement {} (from {}) with unrecognized VCS: {}'.format(
+                    str(self),
+                    str(self._install_req),
+                    self.vcs
+                )
         setup_dict, err = setup_py.setup_info_dir(tmpdir)
         if err is not None:
             return None, err

--- a/pydep/req_test.py
+++ b/pydep/req_test.py
@@ -1,14 +1,12 @@
 import unittest
-import pkg_resources as pr
-import pip.req
-import tempfile
-import os
-from os import path
-from req import *
+from pip import req as req
+
+from pydep.req import *
 
 testdatadir = path.join(path.dirname(__file__), 'testdata')
 
-class Test_requirements(unittest.TestCase):
+
+class TestRequirements(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
 
@@ -61,10 +59,12 @@ class Test_requirements(unittest.TestCase):
                 {'key': 'https://code.google.com/p/foo',
                  'repo_url': 'https://code.google.com/p/foo',
                  'type': 'vcs',
-                 'modules': None, 'extras': None, 'packages': None, 'project_name': None, 'resolved': False, 'specs': None, 'unsafe_name': None},
+                 'modules': None, 'extras': None, 'packages': None, 'project_name': None, 'resolved': False,
+                 'specs': None, 'unsafe_name': None},
                 {'key': 'https://github.com/foo/bar',
                  'repo_url': 'https://github.com/foo/bar',
-                 'type': 'vcs', 'extras': None, 'modules': None, 'packages': None, 'project_name': None, 'resolved': False, 'specs': None, 'unsafe_name': None},
+                 'type': 'vcs', 'extras': None, 'modules': None, 'packages': None, 'project_name': None,
+                 'resolved': False, 'specs': None, 'unsafe_name': None},
                 {'extras': (),
                  'key': 'foo',
                  'project_name': 'foo',
@@ -81,44 +81,44 @@ class Test_requirements(unittest.TestCase):
             dir_, exp = testcase[0], testcase[1]
             rootdir = path.join(testdatadir, dir_)
             reqs, err = requirements(rootdir, resolve=False)
-            if err != None:
+            if err is not None:
                 if exp != '<<ERROR>>':
-                    print 'unexpected error: ', err
+                    print('unexpected error: ', err)
                 self.assertEqual(exp, '<<ERROR>>')
             else:
-                self.assertListEqual(sorted(exp), sorted(reqs))
+                self.assertListEqual(sorted(exp, key=lambda x: x['key']), sorted(reqs, key=lambda x: x['key']))
 
     def test_SetupToolsRequirement(self):
         testcases = [
             ("foo==0.0.0", {
-                 'extras': (),
-                 'key': 'foo',
-                 'modules': None,
-                 'packages': None,
-                 'project_name': 'foo',
-                 'repo_url': None,
-                 'resolved': False,
-                 'specs': [('==', '0.0.0')],
-                 'type': 'setuptools',
-                 'unsafe_name': 'foo'
-             }),
+                'extras': (),
+                'key': 'foo',
+                'modules': None,
+                'packages': None,
+                'project_name': 'foo',
+                'repo_url': None,
+                'resolved': False,
+                'specs': [('==', '0.0.0')],
+                'type': 'setuptools',
+                'unsafe_name': 'foo'
+            }),
             ("foo[bar]>=0.1b", {
-                 'extras': ('bar',),
-                 'key': 'foo',
-                 'modules': None,
-                 'packages': None,
-                 'project_name': 'foo',
-                 'repo_url': None,
-                 'resolved': False,
-                 'specs': [('>=', '0.1b')],
-                 'type': 'setuptools',
-                 'unsafe_name': 'foo'
+                'extras': ('bar',),
+                'key': 'foo',
+                'modules': None,
+                'packages': None,
+                'project_name': 'foo',
+                'repo_url': None,
+                'resolved': False,
+                'specs': [('>=', '0.1b')],
+                'type': 'setuptools',
+                'unsafe_name': 'foo'
             }),
         ]
         for testcase in testcases:
             req_str, exp_dict = testcase[0], testcase[1]
-            req = SetupToolsRequirement(pr.Requirement.parse(req_str))
-            self.assertDictEqual(exp_dict, req.to_dict())
+            st_req = SetupToolsRequirement(pr.Requirement.parse(req_str))
+            self.assertDictEqual(exp_dict, st_req.to_dict())
 
     def test_PipVCSInstallRequirement(self):
         requirements_str = """
@@ -131,13 +131,15 @@ class Test_requirements(unittest.TestCase):
                 'type': 'vcs',
                 'key': 'https://github.com/foo/bar',
                 'repo_url': 'https://github.com/foo/bar',
-                'unsafe_name': None, 'extras': None, 'modules': None, 'packages': None, 'project_name': None, 'resolved': False, 'specs': None,
+                'unsafe_name': None, 'extras': None, 'modules': None, 'packages': None, 'project_name': None,
+                'resolved': False, 'specs': None,
             },
             {
                 'type': 'vcs',
                 'key': 'https://code.google.com/p/foo',
                 'repo_url': 'https://code.google.com/p/foo',
-                'unsafe_name': None, 'extras': None, 'modules': None, 'packages': None, 'project_name': None, 'resolved': False, 'specs': None,
+                'unsafe_name': None, 'extras': None, 'modules': None, 'packages': None, 'project_name': None,
+                'resolved': False, 'specs': None,
             },
             {
                 'type': 'vcs',
@@ -145,14 +147,14 @@ class Test_requirements(unittest.TestCase):
                 'repo_url': 'git://code.google.com/p/foo',
                 'unsafe_name': 'bar',
                 'project_name': 'bar',
-                'specs': [], 'extras': (), 'modules': None, 'packages': None,  'resolved': False,
+                'specs': [], 'extras': (), 'modules': None, 'packages': None, 'resolved': False,
             },
         ]
 
         _, requirements_file = tempfile.mkstemp()
         with open(requirements_file, 'w') as f:
             f.write(requirements_str)
-        pip_reqs = pip.req.parse_requirements(requirements_file, session=pip.download.PipSession())
+        pip_reqs = req.parse_requirements(requirements_file, session=pip.download.PipSession())
         reqs = [PipURLInstallRequirement(r).to_dict() for r in pip_reqs]
         os.remove(requirements_file)
 

--- a/pydep/setup_py.py
+++ b/pydep/setup_py.py
@@ -1,11 +1,11 @@
 import sys
-import pkg_resources as pr
-import tempfile
-import shutil
-import subprocess
 import os
 import runpy
 from os import path
+
+
+PY2 = sys.version_info[0] == 2
+
 
 def setup_dirs(container_dir):
     """
@@ -21,6 +21,7 @@ def setup_dirs(container_dir):
                 break
     return rootdirs
 
+
 def setup_info_dir(rootdir):
     """
     Returns (metadata, error_string) tuple. error_string is None if no error.
@@ -30,40 +31,44 @@ def setup_info_dir(rootdir):
         return None, 'setup.py does not exist'
     return setup_info(setupfile), None
 
+
 def setup_info(setupfile):
     """Returns metadata for a PyPI package by running its setupfile"""
     setup_dict = {}
+
     def setup_replacement(**kw):
-        for k, v in kw.iteritems():
+        iter = kw.iteritems() if PY2 else kw.items()
+        for k, v in iter:
             setup_dict[k] = v
 
     setuptools_mod = __import__('setuptools')
-    import distutils.core # for some reason, __import__('distutils.core') doesn't work
+    import distutils.core  # for some reason, __import__('distutils.core') doesn't work
 
     # Mod setup()
     old_setuptools_setup = setuptools_mod.setup
     setuptools_mod.setup = setup_replacement
     old_distutils_setup = distutils.core.setup
     distutils.core.setup = setup_replacement
-    # Mod sys.path (changing sys.path is necessary in addition to changing the working dir, because of Python's import resolution order)
+    # Mod sys.path (changing sys.path is necessary in addition to changing the working dir,
+    # because of Python's import resolution order)
     old_sys_path = list(sys.path)
     sys.path.insert(0, path.dirname(setupfile))
     # Change working dir (necessary because some setup.py files read relative paths from the filesystem)
     old_wd = os.getcwd()
     os.chdir(path.dirname(setupfile))
     # Redirect stdout to stderr (*including for subprocesses*)
-    old_sys_stdout = sys.stdout # redirects in python process
+    old_sys_stdout = sys.stdout  # redirects in python process
     sys.stdout = sys.stderr
-    old_stdout = os.dup(1)      # redirects in subprocesses
+    old_stdout = os.dup(1)  # redirects in subprocesses
     stderr_dup = os.dup(2)
     os.dup2(stderr_dup, 1)
 
     runpy.run_path(path.basename(setupfile), run_name='__main__')
 
     # Restore stdout
-    os.dup2(old_stdout, 1)      # restores for subprocesses
+    os.dup2(old_stdout, 1)  # restores for subprocesses
     os.close(stderr_dup)
-    sys.stdout = old_sys_stdout # restores for python process
+    sys.stdout = old_sys_stdout  # restores for python process
     # Restore working dir
     os.chdir(old_wd)
     # Restore sys.path

--- a/pydep/testdata/ex_setuppy_prints/setup.py
+++ b/pydep/testdata/ex_setuppy_prints/setup.py
@@ -5,7 +5,7 @@ A package representative of Python dependency management best practices.
 from setuptools import setup
 import subprocess
 
-print 'THIS SHOULD NOT APPEAR IN OUTPUT (but will in test)'
+print('THIS SHOULD NOT APPEAR IN OUTPUT (but will in test)')
 subprocess.call(['echo', 'THIS SHOULD NOT APPEAR IN OUTPUT EITHER (but will in test)'])
 
 setup(

--- a/pydep/vcs.py
+++ b/pydep/vcs.py
@@ -6,6 +6,7 @@ repo_url_patterns = [
     r'(?:git\+|hg\+)?((?:https?|git|hg)\://code.google.com/p/(?:[^/#]+))(?:/.*)?',
 ]
 
+
 def parse_repo_url(url):
     """Returns the canonical repository clone URL from a string that contains it"""
     for pattern in repo_url_patterns:

--- a/pydep/vcs_test.py
+++ b/pydep/vcs_test.py
@@ -1,5 +1,6 @@
 import unittest
-from vcs import parse_repo_url
+from pydep.vcs import parse_repo_url
+
 
 class TestVCS(unittest.TestCase):
     def test_parse_repo_url(self):


### PR DESCRIPTION
Sorry about the dirty history. The actual change is in the last commit.

This fixes #7.

Python3 compatibility works as long as project doesn't depend on non-Python3 compatible project (and even then if the conflicting code is in `setup.py`).