### PR TITLE
Windows support - deletion of read-only files

### DIFF
--- a/pydep-run.py
+++ b/pydep-run.py
@@ -5,6 +5,7 @@ import json
 import argparse
 import pydep.req
 import pydep.setup_py
+import pydep.util
 
 from os import path
 import subprocess
@@ -120,7 +121,7 @@ def smoke_test(args):
         print('failed with exception %s' % str(e))
     finally:
         if tmpdir:
-            shutil.rmtree(tmpdir)
+            util.rmtree(tmpdir)
 
 #
 # Helpers

--- a/pydep/req.py
+++ b/pydep/req.py
@@ -14,6 +14,7 @@ from glob import glob
 from os import path
 
 from pydep import setup_py
+from pydep.util import rmtree
 from pydep.vcs import parse_repo_url
 
 
@@ -126,14 +127,14 @@ class SetupToolsRequirement(object):
                        '--no-binary', ':all:', str(self.req)]
                 pip.main(cmd)
             except Exception as e:
-                shutil.rmtree(tmp_dir)
+                rmtree(tmp_dir)
                 return 'error downloading requirement: {}'.format(str(e))
 
         project_dir = path.join(tmp_dir, self.req.project_name)
         setup_dict, err = setup_py.setup_info_dir(project_dir)
         if err is not None:
             return None, err
-        shutil.rmtree(tmp_dir)
+        rmtree(tmp_dir)
 
         self.metadata = setup_dict
         return None
@@ -226,7 +227,7 @@ class PipURLInstallRequirement(object):
         setup_dict, err = setup_py.setup_info_dir(tmpdir)
         if err is not None:
             return None, err
-        shutil.rmtree(tmpdir)
+        rmtree(tmpdir)
         self.metadata = setup_dict
         return None
 

--- a/pydep/util.py
+++ b/pydep/util.py
@@ -17,6 +17,3 @@ def rmtree(dir):
 def __fix_read_only(fn, path, excinfo):
 	os.chmod(path, stat.S_IWRITE)
 	fn(path)
-
-if __name__ == '__main__':
-	rmtree('C:/Users/lyolik/AppData/Local/Temp/tmpvbovbo')

--- a/pydep/util.py
+++ b/pydep/util.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+import stat
+import sys
+
+
+def rmtree(dir):
+	"""
+	Recursivly removes files in a given dir. 
+	On Windows tries to remove readonly files (i.e. contents of .git)
+	"""
+	if sys.platform == 'win32' or sys.platform == 'cygwin' or sys.platform == 'msys':
+		shutil.rmtree(dir, onerror =__fix_read_only)
+	else:
+		shutil.rmtree(dir)
+
+def __fix_read_only(fn, path, excinfo):
+	os.chmod(path, stat.S_IWRITE)
+	fn(path)
+
+if __name__ == '__main__':
+	rmtree('C:/Users/lyolik/AppData/Local/Temp/tmpvbovbo')


### PR DESCRIPTION
When we were failed to delete file, let's try to clear read-only mark and retry deletion. Some programs (i.e. git) marks their files as read-only and shutil.rmtree fails to remove them