### PR TITLE
Bugfixes, Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ For example,
 
 Additional requirements
 -----
-- Unix (Windows is untested and will probably fail, because, e.g., things get piped to /dev/null in a few places)
 - pip 7.0+
 - curl, unzip, gunzip, tar
 

--- a/pydep-run.py
+++ b/pydep-run.py
@@ -7,7 +7,7 @@ import pydep.req
 import pydep.setup_py
 import pydep.util
 
-from os import path
+from os import path, devnull
 import subprocess
 import tempfile
 import shutil
@@ -95,8 +95,8 @@ def smoke_test(args):
             print('Downloading and processing %s...' % title)
             subdir = path.splitext(path.basename(cloneURL))[0]
             dir_ = path.join(tmpdir, subdir)
-            with open('/dev/null', 'w') as devnull:
-                subprocess.call(['git', 'clone', cloneURL, dir_], stdout=devnull, stderr=devnull)
+            with open(devnull , 'w') as handle:
+                subprocess.call(['git', 'clone', cloneURL, dir_], stdout=handle, stderr=handle)
 
             print('')
             reqs, err = pydep.req.requirements(dir_, True)
@@ -121,7 +121,7 @@ def smoke_test(args):
         print('failed with exception %s' % str(e))
     finally:
         if tmpdir:
-            util.rmtree(tmpdir)
+            pydep.util.rmtree(tmpdir)
 
 #
 # Helpers

--- a/pydep/req_test.py
+++ b/pydep/req_test.py
@@ -151,11 +151,13 @@ class TestRequirements(unittest.TestCase):
             },
         ]
 
-        _, requirements_file = tempfile.mkstemp()
+        handle, requirements_file = tempfile.mkstemp()
         with open(requirements_file, 'w') as f:
             f.write(requirements_str)
+
         pip_reqs = req.parse_requirements(requirements_file, session=pip.download.PipSession())
         reqs = [PipURLInstallRequirement(r).to_dict() for r in pip_reqs]
+        os.fdopen(handle).close()
         os.remove(requirements_file)
 
         self.assertListEqual(expected, reqs)

--- a/pydep/vcs.py
+++ b/pydep/vcs.py
@@ -18,6 +18,8 @@ def parse_repo_url(url):
 def parse_repo_url_and_revision(url):
     """Returns the canonical repository clone URL and revision from a string that contains it"""
     full_url = parse_repo_url(url)
+    if full_url is None:
+        return url, '' # fall back to returning the full URL
     components = full_url.split('@')
     if len(components) == 2:
         return components[0], components[1]

--- a/pydep/vcs_test.py
+++ b/pydep/vcs_test.py
@@ -1,5 +1,5 @@
 import unittest
-from pydep.vcs import parse_repo_url
+from pydep.vcs import parse_repo_url, parse_repo_url_and_revision
 
 
 class TestVCS(unittest.TestCase):
@@ -21,7 +21,21 @@ class TestVCS(unittest.TestCase):
             ('git+git://bitbucket.org/foo/bar', 'git://bitbucket.org/foo/bar'),
 
             ('https://google.com', None),
+
+            ('file:///tmp/', None),
         ]
 
         for testcase in testcases:
             self.assertEqual(testcase[1], parse_repo_url(testcase[0]))
+
+    def test_parse_repo_url_and_revision(self):
+        testcases = [
+            ('http://github.com/foo/bar', 'http://github.com/foo/bar', ''),
+            ('http://github.com/foo/bar@12345', 'http://github.com/foo/bar', '12345'),
+            ('file:///tmp/', 'file:///tmp/', ''),
+        ]
+
+        for testcase in testcases:
+            (url, rev) = parse_repo_url_and_revision(testcase[0])
+            self.assertEqual(testcase[1], url)
+            self.assertEqual(testcase[2], rev)


### PR DESCRIPTION
- fixes #16
- using `os.devnull` instead of hardcoded `/dev/null`
- corrected package name (`pydep-run.py demo` failed)