### PR TITLE
Filter out unwanted subdirs

### DIFF
--- a/pydep/setup_py.py
+++ b/pydep/setup_py.py
@@ -14,11 +14,20 @@ def setup_dirs(container_dir):
     contain a setup.py)
     """
     rootdirs = []
-    for dirpath, _, filenames in os.walk(container_dir):
+    for dirpath, dirnames, filenames in os.walk(container_dir):
         for filename in filenames:
             if filename == 'setup.py':
                 rootdirs.append(dirpath)
                 break
+
+        # Clean up unwanted subdirectories before next walk.
+        newnames = []
+        for dirname in dirnames:
+            if dirname.startswith(".") or dirname.startswith("virtualenv_") or dirname == "testdata":
+                continue
+            newnames.append(dirname)
+        dirnames[:] = newnames
+
     return rootdirs
 
 


### PR DESCRIPTION
Currently `os.walk` iterates all subdirs including unwanted `.git`, `.env`, etc. Then we filter out those directories on caller side. 

After merged this PR, we're able to avoid iterating unwanted subdirs at all, which also gain some performance when unwanted subdirs are a lot and deep.

Related to https://github.com/sourcegraph/srclib-python/issues/54