### PR TITLE
Add "license" and "classifiers" fields to output

### DIFF
--- a/pydep-run.py
+++ b/pydep-run.py
@@ -139,6 +139,8 @@ def setup_dict_to_json_serializable_dict(d, **kw):
         'scripts': d['scripts'] if 'scripts' in d else None,
         'author': d['author'] if 'author' in d else None,
         'description': d['description'] if 'description' in d else None,
+        'license': d['license'] if 'license' in d else None,
+        'classifiers': d['classifiers'] if 'classifiers' in d else None,
     }
 
 


### PR DESCRIPTION
We use `pydep` in https://github.com/heremaps/oss-review-toolkit and need to access any license declarations made in `setup.py` (either in the `license` field or as part of the classifiers).